### PR TITLE
Fix context menu positioning

### DIFF
--- a/src/Indiko.Maui.Controls.Chat/Platforms/Android/ChatViewHandler.cs
+++ b/src/Indiko.Maui.Controls.Chat/Platforms/Android/ChatViewHandler.cs
@@ -431,21 +431,19 @@ public class ChatViewHandler : ViewHandler<ChatView, RecyclerView>
 
         var screenHeight = rootView.Height;
 
-        // Ensure the panel does not go out of screen bounds
-        int availableSpaceBelow = screenHeight - messageBottomY;
-        int contextMenuHeight = 250; // Approximate height
+        // Always position the context menu below the pressed message.
+        // This avoids the previous behaviour where the menu could appear
+        // above the message if there was not enough space below.
+        int topMargin = messageBottomY + 20; // Add some spacing
 
-        // Check if there is enough space below the message
-        int topMargin;
-        if (availableSpaceBelow > contextMenuHeight)
+        // Prevent the menu from going off screen when the message is near the
+        // bottom. If there isn't enough space, clamp the position so that the
+        // menu stays within the visible area while remaining below the message.
+        int contextMenuHeight = 250; // Approximate height
+        int maxTopMargin = screenHeight - contextMenuHeight - 20;
+        if (topMargin > maxTopMargin)
         {
-            // Enough space below the message
-            topMargin = messageBottomY + 20; // Add some spacing
-        }
-        else
-        {
-            // Not enough space, position it **above the message** instead
-            topMargin = location[1] - contextMenuHeight - 20;
+            topMargin = maxTopMargin;
         }
 
         // Set layout params


### PR DESCRIPTION
## Summary
- keep context menu under the pressed message on Android

## Testing
- `dotnet test src/Indiko.Maui.Controls.Chat.sln` *(fails: workloads not installed)*